### PR TITLE
Fix production build typo in purge array

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './component/**/*.{js,ts,jsx,tsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},


### PR DESCRIPTION
Hey!

This solves the purging issue.

By the way, you should try to add `mode: 'jit'` in your config file to enable the new JIT engine, so much faster!

JIT engine will also make you realise at dev time if the purge settings are not correct, since nothing will compile (that's how I debugged).

You might want to change your `components` folder to have the `s` instead of changing the path in the purge array, but I thought I'd open this PR to show you the fix for your current problem.

Hope it helps!